### PR TITLE
ci: typo in publish workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           cache: 'poetry'
 
       - name: Install Dependencies
-        run: poetry install
+        run: poetry install --with dev
 
       - name: Run tests with Nox
         run: poetry run nox -s lint tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,10 +22,10 @@ jobs:
         cache: 'poetry'
 
     - name: Install dependencies
-      run: poetry install
+      run: poetry install --with dev
 
     - name: Run tests
-      run: poetry nox -s tests
+      run: poetry run nox -s tests
     - name: Publish package
       run: |
         poetry config repositories.packagr ${{ secrets.PACKAGR_REPOSITORY_URL }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # DTM
-[![Build Status](https://travis-ci.com/SevanSSP/dtm.svg?token=3uQ4z5yHC2AVPsxguFuR&branch=master)](https://travis-ci.com/SevanSSP/dtm)
+[![Build and test package](https://github.com/SevanSSP/dtm/actions/workflows/build.yml/badge.svg)](https://github.com/SevanSSP/dtm/actions/workflows/build.yml)
+[![Publish Python package to Packagr](https://github.com/SevanSSP/dtm/actions/workflows/publish.yml/badge.svg)](https://github.com/SevanSSP/dtm/actions/workflows/publish.yml)
 ## Description
 Python package for managing tasks executed in parallel processes.
 
@@ -9,7 +10,7 @@ A task is defined by a **command** and a **work directory**. The work directory 
 Install the package from Packagr using pip
 
 ```bash
- pip install dtm --extra-index-url https://api.packagr.app/EYvhW6SyL/ --disable-pip-version-check
+ pip install dtm --extra-index-url https://api.packagr.app/EYvhW6SyL/
 ```
 
 ## Usage

--- a/poetry.lock
+++ b/poetry.lock
@@ -263,4 +263,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1, < 3.13"
-content-hash = "86a5125627b7e63855b16b27819e7d3208d4c058e2ff6f44ac8089dc275ec387"
+content-hash = "940b3783c6898d2cc7dc6f56da4f5624df3c43919ea8f15d1fd0dd0e11ac6f71"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dtm"
-version = "0.2.2"
+version = "0.3.0"
 description = ""
 authors = ["tovop <pev@sevassp.com>",
            "EBGlom <ebg@sevassp.com>"]
@@ -8,7 +8,7 @@ authors = ["tovop <pev@sevassp.com>",
 [tool.poetry.dependencies]
 python = ">=3.8.1, < 3.13"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^8.3.2"
 nox = "^2024.4.15"
 flake8 = "^7.1.1"


### PR DESCRIPTION
Publish action got broken by last commit, update the test step to use `poetry run`

Also update poetry syntax to post v1.2 syntax for dev dependencies